### PR TITLE
fix incorrect use of weak reference

### DIFF
--- a/src/main/java/net/dries007/holoInventory/server/ServerEventHandler.java
+++ b/src/main/java/net/dries007/holoInventory/server/ServerEventHandler.java
@@ -241,12 +241,13 @@ public class ServerEventHandler {
 
     private IInventory getCachedPatternsWrapper(WorldServer world, String name, IInventory patterns) {
         CachedPatternInventory cache = wrappedInventoryCache.get(patterns);
-        if (cache == null || cache.inventory.get() == null
+        IInventory ret;
+        if (cache == null || (ret = cache.inventory.get()) == null
                 || cache.hash != CachedPatternInventory.computeHash(patterns)) {
-            cache = new CachedPatternInventory(convertToOutputItems(name, patterns, world), patterns);
+            cache = new CachedPatternInventory(ret = convertToOutputItems(name, patterns, world), patterns);
             wrappedInventoryCache.put(patterns, cache);
         }
-        return cache.inventory.get();
+        return ret;
     }
 
     private void checkForChangedType(int id, TileEntity te) {


### PR DESCRIPTION
Fix https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/13079

if unfortunate things can happen, it will happen. gc kick in after CachedPatternInventory is created, but before cache.inventory.get() has returned and cleared the WeakReference before it is ever used.

TBH it's highly questionable to use WeakReference as a cache. SoftReference combined with a expiration time or more complex custom cache clearing mechanism is a much better choice, or just simply guava cache, but I'm too lazy 😛