### PR TITLE
Fix strange rotation when rendering with Angelica

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -117,7 +117,7 @@ minimizeShadowedDependencies = true
 # If disabled, won't rename the shadowed classes.
 relocateShadowedDependencies = true
 
-# Adds the GTNH maven, CurseMaven, IC2/Player maven, and some more well-known 1.7.10 repositories.
+# Adds the GTNH maven, CurseMaven, Modrinth, and some more well-known 1.7.10 repositories.
 includeWellKnownRepositories = true
 
 # Change these to your Maven coordinates if you want to publish to a custom Maven repository instead of the default GTNH Maven.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.14'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.21'
 }
 
 

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -10,6 +10,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.item.ItemStack;
@@ -165,10 +166,14 @@ public class GroupRenderer {
         GL11.glTranslatef(width - ((column + 0.2f) * scale * spacing), height - ((row + 0.05f) * scale * spacing), 0f);
         GL11.glTranslatef(0, offset, 0);
         GL11.glScalef(scale, scale, scale);
-        if (Minecraft.getMinecraft().gameSettings.fancyGraphics)
+        RenderItem.renderInFrame = true;
+        if (Minecraft.getMinecraft().gameSettings.fancyGraphics) {
             GL11.glRotatef(Config.rotateItems ? time : 0f, 0.0F, 1.0F, 0.0F);
-        else GL11.glRotatef(RenderManager.instance.playerViewY, 0.0F, 1.0F, 0.0F);
+        } else {
+            GL11.glRotatef(180.0F, 0.0F, 1.0F, 0.0F);
+        }
         ClientHandler.RENDER_ITEM.doRender(fakeEntityItem, 0, 0, 0, 0, 0);
+        RenderItem.renderInFrame = false;
         GL11.glPopMatrix();
         RenderHelper.disableStandardItemLighting();
         if (renderText && stackSizeText != null) {


### PR DESCRIPTION
Tested with and without Angelica, on fast and fancy item rendering. I'm not sure what the root cause was but I switched from dropped item rendering to item frame rendering, this way the hack of doing, then undoing player rotation is no longer needed.

Fixes https://github.com/GTNewHorizons/Angelica/issues/431 for me