### PR TITLE
Fix TF Magic Map Rendering

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,8 @@ dependencies {
 	compileOnly("com.github.GTNewHorizons:StorageDrawers:1.13.5-GTNH:dev") { transitive = false }
 	compileOnly("com.github.GTNewHorizons:Jabba:1.3.3:dev") { transitive = false }
 	compileOnly('curse.maven:minefactory-reloaded-66672:2366150') { transitive = false }
+	compileOnly("com.github.GTNewHorizons:twilightforest:2.5.16:dev") { transitive = false }
 	// for testing
 	//runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.45.161:dev")
+
 }

--- a/src/main/java/net/dries007/holoInventory/HoloInventory.java
+++ b/src/main/java/net/dries007/holoInventory/HoloInventory.java
@@ -74,7 +74,7 @@ public class HoloInventory {
     private SimpleNetworkWrapper snw;
     private Logger logger;
 
-    public static boolean isBaublesLoaded, isTinkersLoaded, isAE2Loaded = false;
+    public static boolean isBaublesLoaded, isTinkersLoaded, isAE2Loaded, isTFLoaded = false;
 
     @Mod.EventHandler()
     public void preInit(FMLPreInitializationEvent event) {
@@ -82,6 +82,7 @@ public class HoloInventory {
         isBaublesLoaded = Loader.isModLoaded("Baubles");
         isTinkersLoaded = Loader.isModLoaded("TConstruct");
         isAE2Loaded = Loader.isModLoaded("appliedenergistics2");
+        isTFLoaded = Loader.isModLoaded("TwilightForest");
 
         logger = event.getModLog();
         config = new Config(event.getSuggestedConfigurationFile());

--- a/src/main/java/net/dries007/holoInventory/HoloInventory.java
+++ b/src/main/java/net/dries007/holoInventory/HoloInventory.java
@@ -50,7 +50,7 @@ import cpw.mods.fml.relauncher.Side;
         version = HoloInventory.VERSION,
         acceptableRemoteVersions = "*",
         acceptedMinecraftVersions = "[1.7.10]",
-        dependencies = "after:Baubles;after:TConstruct")
+        dependencies = "after:Baubles;after:TConstruct;after:TwilightForest")
 public class HoloInventory {
 
     public static final String MODID = "holoinventory";

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -160,18 +160,14 @@ public class GroupRenderer {
 
             if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.magicmap")) {
                 renderStack = new ItemStack(TFItems.emptyMagicMap, 1, 0);
-            }
-            else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.mazemap")) {
+            } else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.mazemap")) {
                 renderStack = new ItemStack(TFItems.emptyMazeMap, 1, 0);
-            }
-            else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.oremap")) {
+            } else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.oremap")) {
                 renderStack = new ItemStack(TFItems.emptyOreMap, 1, 0);
             }
         }
 
-        if (renderStack == null)
-            renderStack = itemStack.copy();
-
+        if (renderStack == null) renderStack = itemStack.copy();
 
         if (!Config.renderMultiple) {
             renderStack.stackSize = 1;

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -15,6 +15,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
 import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.entity.item.EntityItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
@@ -38,6 +39,8 @@ public class GroupRenderer {
     private final EntityItem fakeEntityItem = new EntityItem(Minecraft.getMinecraft().theWorld);
     private static final int TEXT_COLOR = 255 + (255 << 8) + (255 << 16) + (170 << 24);
     private static final MethodHandle angelicaFancyItemsSetter, angelicaFancyItemsGetter;
+    // used for TF maps that cause issues with angelica and holoinventory
+    private static final ItemStack emptyMagicMap, emptyMazeMap, emptyOreMap;
 
     static {
         MethodHandle fancyItemsSetter, fancyItemsGetter;
@@ -54,6 +57,16 @@ public class GroupRenderer {
         }
         angelicaFancyItemsSetter = fancyItemsSetter;
         angelicaFancyItemsGetter = fancyItemsGetter;
+
+        if (HoloInventory.isTFLoaded) {
+            emptyMagicMap = new ItemStack(TFItems.emptyMagicMap);
+            emptyMazeMap = new ItemStack(TFItems.emptyMazeMap);
+            emptyOreMap = new ItemStack(TFItems.emptyOreMap);
+        } else {
+            emptyMagicMap = null;
+            emptyMazeMap = null;
+            emptyOreMap = null;
+        }
     }
 
     // changed with an attached debugger..
@@ -156,14 +169,13 @@ public class GroupRenderer {
         // couldn't figure a way to get it to work in TF but not break anything so lets go with this
         // solution: render empty map type instead
         if (HoloInventory.isTFLoaded) {
-            // max stack size is 1 for the original map so lets hardcode it
-
-            if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.magicmap")) {
-                renderStack = new ItemStack(TFItems.emptyMagicMap, 1, 0);
-            } else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.mazemap")) {
-                renderStack = new ItemStack(TFItems.emptyMazeMap, 1, 0);
-            } else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.oremap")) {
-                renderStack = new ItemStack(TFItems.emptyOreMap, 1, 0);
+            Item renderItem = itemStack.getItem();
+            if (renderItem == TFItems.magicMap) {
+                renderStack = emptyMagicMap;
+            } else if (renderItem == TFItems.oreMap) {
+                renderStack = emptyOreMap;
+            } else if (renderItem == TFItems.mazeMap) {
+                renderStack = emptyMazeMap;
             }
         }
 

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -150,17 +150,28 @@ public class GroupRenderer {
      */
     private void renderItem(ItemStack itemStack, int column, int row) {
         if (itemStack == null) return;
-        ItemStack renderStack;
+        ItemStack renderStack = null;
 
-        // TF magic map uses a different item entity renderer which causes issues with holo and Angelica
+        // TF maps uses a different item entity renderer which causes issues with holo and Angelica
         // couldn't figure a way to get it to work in TF but not break anything so lets go with this
-        // solution: render empty magic map instead
-        if (HoloInventory.isTFLoaded && itemStack.getUnlocalizedName().equalsIgnoreCase("item.magicmap")) {
+        // solution: render empty map type instead
+        if (HoloInventory.isTFLoaded) {
             // max stack size is 1 for the original map so lets hardcode it
-            renderStack = new ItemStack(TFItems.emptyMagicMap, 1, 0);
-        } else {
-            renderStack = itemStack.copy();
+
+            if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.magicmap")) {
+                renderStack = new ItemStack(TFItems.emptyMagicMap, 1, 0);
+            }
+            else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.mazemap")) {
+                renderStack = new ItemStack(TFItems.emptyMazeMap, 1, 0);
+            }
+            else if (itemStack.getUnlocalizedName().equalsIgnoreCase("item.oremap")) {
+                renderStack = new ItemStack(TFItems.emptyOreMap, 1, 0);
+            }
         }
+
+        if (renderStack == null)
+            renderStack = itemStack.copy();
+
 
         if (!Config.renderMultiple) {
             renderStack.stackSize = 1;

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -27,6 +27,8 @@ import org.lwjgl.opengl.GL12;
 
 import com.google.common.base.Throwables;
 
+import twilightforest.item.TFItems;
+
 /**
  * Keeps track of render scale, spacing, etc. to draw a set of icons prettier
  */
@@ -148,7 +150,18 @@ public class GroupRenderer {
      */
     private void renderItem(ItemStack itemStack, int column, int row) {
         if (itemStack == null) return;
-        ItemStack renderStack = itemStack.copy();
+        ItemStack renderStack;
+
+        // TF magic map uses a different item entity renderer which causes issues with holo and Angelica
+        // couldn't figure a way to get it to work in TF but not break anything so lets go with this
+        // solution: render empty magic map instead
+        if (HoloInventory.isTFLoaded && itemStack.getUnlocalizedName().equalsIgnoreCase("item.magicmap")) {
+            // max stack size is 1 for the original map so lets hardcode it
+            renderStack = new ItemStack(TFItems.emptyMagicMap, 1, 0);
+        } else {
+            renderStack = itemStack.copy();
+        }
+
         if (!Config.renderMultiple) {
             renderStack.stackSize = 1;
         }


### PR DESCRIPTION
Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16123
(Rotating items is enabled, the missing 1 is because its a max stacksize of 1 and there is only 1 in there)
![image](https://github.com/GTNewHorizons/HoloInventory/assets/18713839/9e8e5e0d-1df7-4f74-bbd4-af30628ada2e)
