### PR TITLE
Add config option to allow HoloInventory to render in third person mode

### DIFF
--- a/src/main/java/net/dries007/holoInventory/Config.java
+++ b/src/main/java/net/dries007/holoInventory/Config.java
@@ -37,6 +37,7 @@ public class Config {
     public static int syncFreq = 2;
     public static boolean renderText = true;
     public static boolean renderSuffixDarkened = true;
+    public static boolean renderThirdPerson = false;
     public static boolean renderMultiple = true;
     public static boolean enableStacking = true;
     public static boolean renderName = true;
@@ -141,6 +142,9 @@ public class Config {
                 "renderSuffixDarkened",
                 renderSuffixDarkened,
                 "Render the stacksize suffix darkened").getBoolean(true);
+        renderThirdPerson = configuration
+                .get(HoloInventory.MODID, "renderThirdPerson", renderThirdPerson, "Render in third person mode")
+                .getBoolean(false);
         renderMultiple = configuration.get(
                 HoloInventory.MODID,
                 "renderMultiple",

--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -114,7 +114,7 @@ public class Renderer {
         final Minecraft mc = Minecraft.getMinecraft();
         if (mc.renderEngine == null || RenderManager.instance == null
                 || RenderManager.instance.getFontRenderer() == null
-                || mc.gameSettings.thirdPersonView != 0
+                || (mc.gameSettings.thirdPersonView != 0 && !Config.renderThirdPerson)
                 || mc.objectMouseOver == null) {
             return;
         }


### PR DESCRIPTION
Adds a config option to turn on rendering of the holo inventory even in third person.  This is false by default, because it does render on top of the player model and can look a bit cluttered, but is useful to enable if you run a mod like Shoulder Surfing that lets you shift the perspective in third person.