### PR TITLE
Add Localization

### DIFF
--- a/src/main/resources/assets/holoinventory/lang/en_US.lang
+++ b/src/main/resources/assets/holoinventory/lang/en_US.lang
@@ -1,2 +1,3 @@
 item.Hologlasses.name=Holo Glasses
+item.fluidRenderFakeItem.name=Fake Fluid Item
 key.categories.holoinventory=Holo Inventory


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.