### PR TITLE
Only render overlay in post

### DIFF
--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -92,7 +92,7 @@ public class Renderer {
 
     // change to RenderGameOverlayEvent so shaders don't effect the render.
     @SubscribeEvent
-    public void renderEvent(RenderGameOverlayEvent event) {
+    public void renderEvent(RenderGameOverlayEvent.Post event) {
         if (!enabled || event.type != ElementType.HELMET || angelicaOverride) {
             return;
         }


### PR DESCRIPTION
Currently, the overlay renderer runs twice: once for the pre event, and once for the post event. This PR changes the subscriber to only render in the post event. This is a minor performance improvement, but it's not anything measurable. It's just something I noticed when profiling containers with a lot of enchanted items. This is very low risk since it was already rendering in the post event, I just removed the pre event.

Before:
https://spark.lucko.me/j6XJrUzYht
![image](https://github.com/user-attachments/assets/859e686b-c8b5-4249-85d6-be71aec3e68b)


After:
https://spark.lucko.me/SM6oLuddU8
![image](https://github.com/user-attachments/assets/e7dff522-9b6e-49e5-a99a-95027dd5c30c)
