### PR TITLE
Fixed improper null checks on fluid info handling

### DIFF
--- a/src/main/java/net/dries007/holoInventory/util/FluidHandlerData.java
+++ b/src/main/java/net/dries007/holoInventory/util/FluidHandlerData.java
@@ -1,8 +1,6 @@
 package net.dries007.holoInventory.util;
 
-import static net.dries007.holoInventory.util.NBTKeys.NBT_KEY_CAPACITY;
-import static net.dries007.holoInventory.util.NBTKeys.NBT_KEY_ID;
-import static net.dries007.holoInventory.util.NBTKeys.NBT_KEY_TANK;
+import static net.dries007.holoInventory.util.NBTKeys.*;
 
 import java.lang.ref.WeakReference;
 import java.util.WeakHashMap;
@@ -49,12 +47,13 @@ public class FluidHandlerData {
         if (tankInfos == null) return tagList;
 
         for (FluidTankInfo tankInfo : tankInfos) {
+            if (tankInfo == null) continue;
+            if (tankInfo.fluid == null) continue;
+
             NBTTagCompound fluidTag = new NBTTagCompound();
-            if (tankInfo.fluid != null) {
-                tankInfo.fluid.writeToNBT(fluidTag);
-                fluidTag.setInteger(NBT_KEY_CAPACITY, tankInfo.capacity);
-                tagList.appendTag(fluidTag);
-            }
+            tankInfo.fluid.writeToNBT(fluidTag);
+            fluidTag.setInteger(NBT_KEY_CAPACITY, tankInfo.capacity);
+            tagList.appendTag(fluidTag);
         }
         return tagList;
     }


### PR DESCRIPTION
Basically I was getting some silly log spam when looking at Steve's Carts blocks due to incorrect null checks. I think this fixed it.

The log spam in questione:

```
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
[17:09:05] [Server thread/WARN] [holoinventory]: Some error while sending over inventory, no hologram for you :(
[17:09:05] [Server thread/WARN] [holoinventory]: Please make an issue on github if this happens.
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: java.lang.NullPointerException: Cannot read field "fluid" because "tankInfo" is null
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.dries007.holoInventory.util.FluidHandlerData.encodeFluidTankInfo(FluidHandlerData.java:53)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.dries007.holoInventory.util.FluidHandlerData.sendIfOld(FluidHandlerData.java:38)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.dries007.holoInventory.server.ServerEventHandler.processFluidHandlerData(ServerEventHandler.java:348)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.dries007.holoInventory.server.ServerEventHandler.handleFluidHandlerBlock(ServerEventHandler.java:337)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.dries007.holoInventory.server.ServerEventHandler.event(ServerEventHandler.java:179)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at cpw.mods.fml.common.eventhandler.ASMEventHandler_1209_ServerEventHandler_event_PlayerTickEvent.invoke(.dynamic)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//cpw.mods.fml.common.FMLCommonHandler.onPlayerPostTick(FMLCommonHandler.java:350)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.entity.player.EntityPlayer.func_70071_h_(EntityPlayer.java:353)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.entity.player.EntityPlayerMP.func_71127_g(EntityPlayerMP.java:295)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetHandlerPlayServer.func_147347_a(NetHandlerPlayServer.java:303)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.play.client.C03PacketPlayer.func_148833_a(SourceFile:137)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.play.client.C03PacketPlayer$C05PacketPlayerLook.func_148833_a(SourceFile:98)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetworkManager.func_74428_b(NetworkManager.java:212)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.network.NetworkSystem.func_151269_c(NetworkSystem.java:165)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71190_q(MinecraftServer.java:659)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.integrated.IntegratedServer.func_71217_p(IntegratedServer.java:111)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427)
[17:09:05] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:785]: 	at Launch//net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)
```