### PR TITLE
Change helmet slot check

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,14 +1,14 @@
 // Add your dependencies here
 
 dependencies {
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.49-GTNH:dev")
-    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-619-GTNH:dev') { transitive = false }
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.8-GTNH:dev') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.28-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:StorageDrawers:2.1.2-GTNH:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Jabba:1.5.4:dev") { transitive = false }
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.7.76-GTNH:dev")
+    compileOnly('com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-675-GTNH:dev') { transitive = false }
+    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.1.13-GTNH:dev') { transitive = false }
+    compileOnly("com.github.GTNewHorizons:TinkersConstruct:1.13.49-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:StorageDrawers:2.1.6-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Jabba:1.5.10:dev") { transitive = false }
     compileOnly('curse.maven:minefactory-reloaded-66672:2366150') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.7:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:twilightforest:2.7.11:dev") { transitive = false }
     // for testing
-    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.324:dev")
+    //runtimeOnlyNonPublishable("com.github.GTNewHorizons:GT5-Unofficial:5.09.51.428:dev")
 }

--- a/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
+++ b/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
@@ -57,9 +57,9 @@ public class HoloGlasses extends ItemArmor implements IHoloGlasses, IBauble, IAc
     }
 
     public static ItemStack getHoloGlasses(World world, EntityPlayer player) {
-        if (player.inventory.getStackInSlot(39) != null
-                && player.inventory.getStackInSlot(39).getItem() instanceof IHoloGlasses)
-            return player.inventory.getStackInSlot(39);
+        if (player.inventory.armorItemInSlot(3) != null
+                && player.inventory.armorItemInSlot(3).getItem() instanceof IHoloGlasses)
+            return player.inventory.armorItemInSlot(3);
 
         if (HoloInventory.isBaublesLoaded) {
             IInventory inventory = BaublesApi.getBaubles(player);


### PR DESCRIPTION
After adding second hand slot, their numeration changed, so 39 slot that was checked earlier, became chestplate instead of helmet, now checking by armor slots.

https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20629