### PR TITLE
Add GTNHLib to dependencies

### DIFF
--- a/src/main/java/net/dries007/holoInventory/HoloInventory.java
+++ b/src/main/java/net/dries007/holoInventory/HoloInventory.java
@@ -50,7 +50,7 @@ import cpw.mods.fml.relauncher.Side;
         version = HoloInventory.VERSION,
         acceptableRemoteVersions = "*",
         acceptedMinecraftVersions = "[1.7.10]",
-        dependencies = "after:Baubles;after:TConstruct;after:TwilightForest")
+        dependencies = "after:Baubles;after:TConstruct;after:TwilightForest;required-after:gtnhlib@[0.9.50,)")
 public class HoloInventory {
 
     public static final String MODID = "holoinventory";


### PR DESCRIPTION
See above, #56 added a dependency to GTNHLib but forgot to add it to the `@Mod` annotation.