### PR TITLE
Check all armor slots for IHoloGlasses

### DIFF
--- a/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
+++ b/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
@@ -69,9 +69,11 @@ public class HoloGlasses extends ItemArmor implements IHoloGlasses, IBauble, IBa
     }
 
     public static ItemStack getHoloGlasses(World world, EntityPlayer player) {
-        if (player.inventory.armorItemInSlot(3) != null
-                && player.inventory.armorItemInSlot(3).getItem() instanceof IHoloGlasses)
-            return player.inventory.armorItemInSlot(3);
+        for (int i = 0; i < 4; i++) {
+            if (player.inventory.armorItemInSlot(i) != null
+                    && player.inventory.armorItemInSlot(i).getItem() instanceof IHoloGlasses)
+                return player.inventory.armorItemInSlot(i);
+        }
 
         if (HoloInventory.isBaublesLoaded) {
             IInventory inventory = BaublesApi.getBaubles(player);


### PR DESCRIPTION
Mechanical armor has the ability to provide holo glasses from each armor slot, but this only checks helmet currently. 

This is already looping through like 25 inventory slots (all baubles and tinkers) so just searching all armor slots should also be fine.