### PR TITLE
Refactor glasses check

### DIFF
--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 
 import net.dries007.holoInventory.Config;
 import net.dries007.holoInventory.HoloInventory;
-import net.dries007.holoInventory.api.IHoloGlasses;
 import net.dries007.holoInventory.items.HoloGlasses;
 import net.dries007.holoInventory.network.EntityRequestMessage;
 import net.dries007.holoInventory.util.Coord;
@@ -43,7 +42,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.village.MerchantRecipe;
 import net.minecraft.village.MerchantRecipeList;
-import net.minecraft.world.World;
 import net.minecraftforge.client.event.RenderGameOverlayEvent;
 import net.minecraftforge.client.event.RenderGameOverlayEvent.ElementType;
 import net.minecraftforge.client.event.RenderWorldLastEvent;
@@ -97,10 +95,8 @@ public class Renderer {
             return;
         }
         final EntityPlayer player = Minecraft.getMinecraft().thePlayer;
-        final World world = Minecraft.getMinecraft().theWorld;
-        final ItemStack glasses = HoloGlasses.getHoloGlasses(world, player);
         try {
-            if (!Config.requireGlasses || glasses != null && ((IHoloGlasses) glasses.getItem()).shouldRender(glasses)) {
+            if (!Config.requireGlasses || HoloGlasses.shouldRender(player)) {
                 doEvent(event.partialTicks);
             }
         } catch (Exception e) {

--- a/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
+++ b/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
@@ -13,7 +13,6 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
-import net.minecraft.world.World;
 import net.minecraftforge.common.util.EnumHelper;
 
 import org.lwjgl.input.Keyboard;
@@ -68,36 +67,34 @@ public class HoloGlasses extends ItemArmor implements IHoloGlasses, IBauble, IBa
         }
     }
 
-    public static ItemStack getHoloGlasses(World world, EntityPlayer player) {
+    public static boolean shouldRender(EntityPlayer player) {
         for (int i = 0; i < 4; i++) {
-            if (player.inventory.armorItemInSlot(i) != null
-                    && player.inventory.armorItemInSlot(i).getItem() instanceof IHoloGlasses)
-                return player.inventory.armorItemInSlot(i);
+            ItemStack armor = player.inventory.armorItemInSlot(i);
+            if (armor != null && armor.getItem() instanceof IHoloGlasses glasses && glasses.shouldRender(armor))
+                return true;
         }
 
         if (HoloInventory.isBaublesLoaded) {
             IInventory inventory = BaublesApi.getBaubles(player);
             for (int i = 0; i != inventory.getSizeInventory(); i++) {
-                if (inventory.getStackInSlot(i) != null
-                        && inventory.getStackInSlot(i).getItem() instanceof IHoloGlasses) {
-                    return inventory.getStackInSlot(i);
+                ItemStack bauble = inventory.getStackInSlot(i);
+                if (bauble != null && bauble.getItem() instanceof IHoloGlasses glasses
+                        && glasses.shouldRender(bauble)) {
+                    return true;
                 }
             }
         }
 
         if (HoloInventory.isTinkersLoaded) {
             IInventory inventory = TPlayerStats.get(player).armor;
-
-            if (world.isRemote) for (int i = 0; i != inventory.getSizeInventory(); i++) {
-                if (ArmorProxyClient.armorExtended.getStackInSlot(i) != null
-                        && ArmorProxyClient.armorExtended.getStackInSlot(i).getItem() instanceof IHoloGlasses)
-                    return ArmorProxyClient.armorExtended.getStackInSlot(i);
+            for (int i = 0; i != inventory.getSizeInventory(); i++) {
+                ItemStack tinkersItem = ArmorProxyClient.armorExtended.getStackInSlot(i);
+                if (tinkersItem != null && tinkersItem.getItem() instanceof IHoloGlasses glasses
+                        && glasses.shouldRender(tinkersItem))
+                    return true;
             }
-            else for (int i = 0; i != inventory.getSizeInventory(); i++) if (inventory.getStackInSlot(i) != null
-                    && inventory.getStackInSlot(i).getItem() instanceof IHoloGlasses)
-                return inventory.getStackInSlot(i);
         }
-        return null;
+        return false;
     }
 
     @Override

--- a/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
+++ b/src/main/java/net/dries007/holoInventory/items/HoloGlasses.java
@@ -1,5 +1,7 @@
 package net.dries007.holoInventory.items;
 
+import static tconstruct.armor.ArmorProxyClient.armorExtended;
+
 import java.util.List;
 
 import net.dries007.holoInventory.HoloInventory;
@@ -26,8 +28,6 @@ import baubles.api.expanded.IBaubleExpanded;
 import cpw.mods.fml.common.Optional.Interface;
 import cpw.mods.fml.common.Optional.InterfaceList;
 import cpw.mods.fml.common.Optional.Method;
-import tconstruct.armor.ArmorProxyClient;
-import tconstruct.armor.player.TPlayerStats;
 import tconstruct.library.accessory.IAccessory;
 
 @InterfaceList({ @Interface(iface = "baubles.api.IBauble", modid = "Baubles|Expanded"),
@@ -86,9 +86,8 @@ public class HoloGlasses extends ItemArmor implements IHoloGlasses, IBauble, IBa
         }
 
         if (HoloInventory.isTinkersLoaded) {
-            IInventory inventory = TPlayerStats.get(player).armor;
-            for (int i = 0; i != inventory.getSizeInventory(); i++) {
-                ItemStack tinkersItem = ArmorProxyClient.armorExtended.getStackInSlot(i);
+            for (int i = 0; i != armorExtended.getSizeInventory(); i++) {
+                ItemStack tinkersItem = armorExtended.getStackInSlot(i);
                 if (tinkersItem != null && tinkersItem.getItem() instanceof IHoloGlasses glasses
                         && glasses.shouldRender(tinkersItem))
                     return true;


### PR DESCRIPTION
https://github.com/GTNewHorizons/HoloInventory/pull/61 exposed an issue with the api usage in HoloInventory. If any IHoloGlasses implementation did anything more complicated than "return true" (e.g. toggles or conditions like are present in mechanical armor) it will block other holo glasses from working.

Instead of just blindly using the shouldRender of the first glasses it finds, it needs to iterate through all slots and return the first one that returns true - if it returns false, it needs to keep checking slots until the list is exhausted.

I also took out some server-side code behind a (!world.isRemote) check because this code literally never runs on the server. It is used in a forge render event that only runs client-side.