### PR TITLE
Refactor/Improve config for rendering the maximum amount of items

### DIFF
--- a/src/main/java/net/dries007/holoInventory/Config.java
+++ b/src/main/java/net/dries007/holoInventory/Config.java
@@ -43,6 +43,7 @@ public class Config {
     public static boolean renderName = true;
     public static boolean hideItemsNotSelected = true;
     public static int mode = 0;
+    public static int maxRenderedItems = 0;
     public static int cycle = 0;
     public static int keyMode = 1;
     public static boolean enableEntities = true;
@@ -178,11 +179,14 @@ public class Config {
                 mode,
                 "Valid modes:\n" + "0: Default mode (Display all items).\n"
                         + "1: Sorting mode, biggest stack size first.\n"
-                        + "2: Most abundant mode (Only display the item the most abundant in the chest.\n"
-                        + "3: Same as 1, but with 3 items.\n"
-                        + "4: Same as 1, but with 5 items.\n"
-                        + "5: Same as 1, but with 7 items.\n"
-                        + "6: Same as 1, but with 9 items.")
+                        + "2: Most abundant mode (Only display the most abundant items in the chest).\nThe exact amount is configured in the \"maxRenderedItems\" config.")
+                .getInt();
+
+        maxRenderedItems = configuration.get(
+                HoloInventory.MODID,
+                "maxRenderedItems",
+                maxRenderedItems,
+                "The maximum amount of items to render, assuming that mode 2 (in the \"mode\" config) is used.\nThe most abundant items will be chosen for rendering.\nIf mode 2 is not used, this configuration is useless.")
                 .getInt();
 
         cycle = configuration.get(

--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -283,13 +283,7 @@ public class Renderer {
 
         List<ItemStack> list = filterByNEI(namedData);
 
-        int wantedSize;
-
-        if (Config.mode == 2) {
-            wantedSize = Config.maxRenderedItems;
-        } else {
-            wantedSize = list.size();
-        }
+        int wantedSize = Config.mode == 2 ? Config.maxRenderedItems : list.size();
 
         if (Config.mode != 0) {
             list.sort(Comparator.<ItemStack>comparingInt(s -> s.stackSize).reversed());

--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -283,29 +283,12 @@ public class Renderer {
 
         List<ItemStack> list = filterByNEI(namedData);
 
-        int wantedSize = list.size();
+        int wantedSize;
 
-        switch (Config.mode) {
-            // Most abundant, 1 item
-            case 2:
-                wantedSize = 1;
-                break;
-            // Most abundant, 3 items
-            case 3:
-                wantedSize = 3;
-                break;
-            // Most abundant, 5 items
-            case 4:
-                wantedSize = 5;
-                break;
-            // Most abundant, 7 items
-            case 5:
-                wantedSize = 7;
-                break;
-            // Most abundant, 9 items
-            case 6:
-                wantedSize = 9;
-                break;
+        if (Config.mode == 2) {
+            wantedSize = Config.maxRenderedItems;
+        } else {
+            wantedSize = list.size();
         }
 
         if (Config.mode != 0) {


### PR DESCRIPTION
## Summary
This PR changes the way that the config is used to control how many items are displayed. Instead of one config controlling both the rendering mode and how many items to render, it is now split into two, with a new `maxRenderedItems` config. If the config value is 2, then the maxRenderedItems is used to determine how many items to render at maximum. This improves the previous behaviour which was limited to only 1, 3, 5, 7 or 9 items. 

Here is a testing result, there are 12 different items in this chest yet due to the config only 6 items are displayed:
<img width="2560" height="1600" alt="Screenshot 2026-07-11 at 4 10 29 PM" src="https://github.com/user-attachments/assets/3fa8207e-5f1f-49a0-94f4-4fac15ba66cc" />

## Checklist
- [x] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
