### PR TITLE
stabilize hologram positioning and brighten dim icons

### DIFF
--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -10,6 +10,7 @@ import net.dries007.holoInventory.HoloInventory;
 import net.dries007.holoInventory.util.Helper;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.entity.RenderItem;
@@ -74,7 +75,7 @@ public class GroupRenderer {
 
     private float scale, width, height, spacing, offset;
     private int columns, rows;
-    private boolean renderText;
+    private boolean renderText, fullBright;
 
     public GroupRenderer() {
         fakeEntityItem.setEntityItemStack(new ItemStack(HoloInventory.fluidRenderFakeItem));
@@ -123,6 +124,10 @@ public class GroupRenderer {
         this.renderText = renderText;
     }
 
+    public void setFullBright(boolean fullBright) {
+        this.fullBright = fullBright;
+    }
+
     public void reset() {
         scale = 0;
         width = 0;
@@ -132,6 +137,7 @@ public class GroupRenderer {
         columns = 0;
         rows = 0;
         renderText = false;
+        fullBright = false;
     }
 
     private float getActualSpacing() {
@@ -215,38 +221,64 @@ public class GroupRenderer {
     }
 
     private void doRenderEntityItem(int column, int row, String stackSizeText) {
-        RenderHelper.enableStandardItemLighting();
+        float previousBrightnessX = OpenGlHelper.lastBrightnessX;
+        float previousBrightnessY = OpenGlHelper.lastBrightnessY;
+        if (fullBright) {
+            // max lightmap brightness
+            OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240f, 240f);
+            RenderHelper.disableStandardItemLighting();
+            GL11.glColor4f(1f, 1f, 1f, 1f);
+        } else {
+            RenderHelper.enableStandardItemLighting();
+        }
+        boolean fancyGraphicsChanged = false;
+        boolean oldFancyGraphics = false;
         GL11.glPushMatrix();
-        GL11.glTranslatef(width - ((column + 0.2f) * scale * spacing), height - ((row + 0.05f) * scale * spacing), 0f);
-        GL11.glTranslatef(0, offset, 0);
-        GL11.glScalef(scale, scale, scale);
-        RenderItem.renderInFrame = true;
-        GL11.glRotatef(Config.rotateItems ? time : 180f, 0.0F, 1.0F, 0.0F);
-        final boolean oldFancyGraphics;
-        if (angelicaFancyItemsSetter != null) {
+        try {
+            GL11.glTranslatef(
+                    width - ((column + 0.2f) * scale * spacing),
+                    height - ((row + 0.05f) * scale * spacing),
+                    0f);
+            GL11.glTranslatef(0, offset, 0);
+            GL11.glScalef(scale, scale, scale);
+            RenderItem.renderInFrame = true;
+            GL11.glRotatef(Config.rotateItems ? time : 180f, 0.0F, 1.0F, 0.0F);
+            if (angelicaFancyItemsSetter != null) {
+                try {
+                    oldFancyGraphics = (boolean) angelicaFancyItemsGetter.invokeExact();
+                    angelicaFancyItemsSetter.invokeExact(true);
+                    fancyGraphicsChanged = true;
+                } catch (Throwable t) {
+                    throw Throwables.propagate(t);
+                }
+            } else {
+                oldFancyGraphics = Minecraft.getMinecraft().gameSettings.fancyGraphics;
+                Minecraft.getMinecraft().gameSettings.fancyGraphics = true;
+                fancyGraphicsChanged = true;
+            }
+            ClientHandler.RENDER_ITEM.doRender(fakeEntityItem, 0, 0, 0, 0, 0);
+        } finally {
             try {
-                oldFancyGraphics = (boolean) angelicaFancyItemsGetter.invokeExact();
-                angelicaFancyItemsSetter.invokeExact(true);
+                if (fancyGraphicsChanged && angelicaFancyItemsSetter != null) {
+                    angelicaFancyItemsSetter.invokeExact(oldFancyGraphics);
+                } else if (fancyGraphicsChanged) {
+                    Minecraft.getMinecraft().gameSettings.fancyGraphics = oldFancyGraphics;
+                }
             } catch (Throwable t) {
                 throw Throwables.propagate(t);
+            } finally {
+                RenderItem.renderInFrame = false;
+                GL11.glMatrixMode(GL11.GL_MODELVIEW);
+                GL11.glPopMatrix();
+                RenderHelper.disableStandardItemLighting();
+                if (fullBright) {
+                    OpenGlHelper.setLightmapTextureCoords(
+                            OpenGlHelper.lightmapTexUnit,
+                            previousBrightnessX,
+                            previousBrightnessY);
+                }
             }
-        } else {
-            oldFancyGraphics = Minecraft.getMinecraft().gameSettings.fancyGraphics;
-            Minecraft.getMinecraft().gameSettings.fancyGraphics = true;
         }
-        ClientHandler.RENDER_ITEM.doRender(fakeEntityItem, 0, 0, 0, 0, 0);
-        if (angelicaFancyItemsSetter != null) {
-            try {
-                angelicaFancyItemsSetter.invokeExact((boolean) oldFancyGraphics);
-            } catch (Throwable t) {
-                throw Throwables.propagate(t);
-            }
-        } else {
-            Minecraft.getMinecraft().gameSettings.fancyGraphics = oldFancyGraphics;
-        }
-        RenderItem.renderInFrame = false;
-        GL11.glPopMatrix();
-        RenderHelper.disableStandardItemLighting();
         if (renderText && stackSizeText != null) {
             GL11.glPushMatrix();
             GL11.glDisable(GL11.GL_DEPTH_TEST);

--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -59,6 +59,8 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class Renderer {
 
+    private static final double MIN_SCALE_DISTANCE = 1.5;
+
     public static final HashMap<Integer, NamedData<ItemStack[]>> tileInventoryMap = new HashMap<>();
     public static final HashMap<Integer, List<FluidTankInfo>> tileFluidHandlerMap = new HashMap<>();
     public static final HashMap<Integer, NamedData<ItemStack[]>> entityMap = new HashMap<>();
@@ -279,7 +281,6 @@ public class Renderer {
     private void renderHologram(@Nullable NamedData<ItemStack[]> namedData,
             @Nullable List<FluidTankInfo> fluidTankInfos) {
         final double distance = distance();
-        if (distance < 1.5) return;
 
         List<ItemStack> list = filterByNEI(namedData);
 
@@ -335,64 +336,68 @@ public class Renderer {
             @Nonnull List<FluidTankInfo> fluidTankInfos, double distance) {
         if (itemStacks.isEmpty() && fluidTankInfos.isEmpty()) return;
 
-        // not sure why blending is happening, but there it is.
-        GL11.glDisable(GL11.GL_BLEND);
-
+        GL11.glPushAttrib(GL11.GL_ALL_ATTRIB_BITS);
+        GL11.glMatrixMode(GL11.GL_MODELVIEW);
         GL11.glPushMatrix();
         GL11.glMatrixMode(GL11.GL_PROJECTION);
         GL11.glPushMatrix();
+        try {
+            // not sure why blending is happening, but there it is.
+            GL11.glDisable(GL11.GL_BLEND);
+            GL11.glEnable(GL11.GL_DEPTH_TEST);
+            GL11.glDepthFunc(GL11.GL_LEQUAL);
+            GL11.glDepthMask(true);
+            // draw in front of world geometry so contents show through the container
+            GL11.glDepthRange(0.0, 0.01);
 
-        GL11.glMatrixMode(GL11.GL_PROJECTION);
-        GL11.glLoadMatrix(ActiveRenderInfo.projection);
-        GL11.glMatrixMode(GL11.GL_MODELVIEW);
-        GL11.glLoadMatrix(ActiveRenderInfo.modelview);
+            GL11.glLoadMatrix(ActiveRenderInfo.projection);
+            GL11.glMatrixMode(GL11.GL_MODELVIEW);
+            GL11.glLoadMatrix(ActiveRenderInfo.modelview);
 
-        // Move to right position and rotate to face the player
-        moveAndRotate(-1);
+            // Move to right position and rotate to face the player
+            moveAndRotate(0);
 
-        double uiScaleFactor = Config.renderScaling;
-        if (uiScaleFactor < 0.1) uiScaleFactor = 0.1;
-        GL11.glScaled(uiScaleFactor, uiScaleFactor, uiScaleFactor);
+            double uiScaleFactor = Math.max(Config.renderScaling, 0.1) * closeRangeScale(distance);
+            GL11.glScaled(uiScaleFactor, uiScaleFactor, uiScaleFactor);
 
-        preRenderHologramItems(itemStacks, distance);
-        preRenderHologramFluids(fluidTankInfos, distance);
+            preRenderHologramItems(itemStacks, distance);
+            preRenderHologramFluids(fluidTankInfos, distance);
 
-        itemGroupRenderer.setOffset(fluidGroupRenderer.calculateOffset());
+            itemGroupRenderer.setOffset(fluidGroupRenderer.calculateOffset());
 
-        // Render the BG
-        if (Config.colorEnable) {
-            List<GroupRenderer> list = new ArrayList<>();
-            if (!itemStacks.isEmpty()) {
-                list.add(itemGroupRenderer);
+            // Render the BG
+            if (Config.colorEnable) {
+                List<GroupRenderer> list = new ArrayList<>();
+                if (!itemStacks.isEmpty()) {
+                    list.add(itemGroupRenderer);
+                }
+                if (!fluidTankInfos.isEmpty()) {
+                    list.add(fluidGroupRenderer);
+                }
+                GroupRenderer.renderBG(list.toArray(new GroupRenderer[0]));
             }
-            if (!fluidTankInfos.isEmpty()) {
-                list.add(fluidGroupRenderer);
+
+            // Render the inv name
+            if (Config.renderName && name != null) {
+                GroupRenderer.renderName(name, itemGroupRenderer, fluidGroupRenderer);
             }
-            GroupRenderer.renderBG(list.toArray(new GroupRenderer[0]));
+
+            renderHologramItems(itemStacks);
+            renderHologramFluids(fluidTankInfos);
+        } finally {
+            GL11.glMatrixMode(GL11.GL_PROJECTION);
+            GL11.glPopMatrix();
+            GL11.glMatrixMode(GL11.GL_MODELVIEW);
+            GL11.glPopMatrix();
+            GL11.glPopAttrib();
         }
-
-        // Render the inv name
-        if (Config.renderName && name != null) {
-            GroupRenderer.renderName(name, itemGroupRenderer, fluidGroupRenderer);
-        }
-
-        renderHologramItems(itemStacks);
-        renderHologramFluids(fluidTankInfos);
-
-        // Undo our changes to the matrices, though the warped UI was hilarious.
-        GL11.glMatrixMode(GL11.GL_PROJECTION);
-        GL11.glPopMatrix();
-        GL11.glMatrixMode(GL11.GL_MODELVIEW);
-        GL11.glPopMatrix();
-
-        GL11.glEnable(GL11.GL_BLEND);
     }
 
     private void preRenderHologramItems(List<ItemStack> itemStacks, double distance) {
         if (itemStacks.isEmpty()) return;
 
         // See if we need to increase spacing
-        float stackSpacing = 0.6f;
+        float stackSpacing = 0.65f;
         if (Config.renderText) {
             for (ItemStack stack : itemStacks) {
                 if (stack.stackSize >= 1000 || GroupRenderer.stackSizeDebugOverride >= 1000) {
@@ -404,9 +409,10 @@ public class Renderer {
 
         itemGroupRenderer.calculateColumns(itemStacks.size());
         itemGroupRenderer.calculateRows(itemStacks.size());
-        itemGroupRenderer.setScale((float) (0.05f * distance));
+        itemGroupRenderer.setScale((float) (0.065 * scaleDistance(distance)));
         itemGroupRenderer.setSpacing(stackSpacing);
         itemGroupRenderer.setRenderText(Config.renderText);
+        itemGroupRenderer.setFullBright(true);
     }
 
     private void renderHologramItems(List<ItemStack> itemStacks) {
@@ -418,7 +424,7 @@ public class Renderer {
         if (fluidTankInfos.isEmpty()) return;
 
         // See if we need to increase spacing
-        float spacing = 0.6f;
+        float spacing = 0.65f;
         if (Config.renderText) {
             for (FluidTankInfo fluidTankInfo : fluidTankInfos) {
                 if (fluidTankInfo.fluid.amount >= 1000) {
@@ -430,14 +436,25 @@ public class Renderer {
 
         fluidGroupRenderer.calculateColumns(fluidTankInfos.size());
         fluidGroupRenderer.calculateRows(fluidTankInfos.size());
-        fluidGroupRenderer.setScale((float) (0.05f * distance));
+        fluidGroupRenderer.setScale((float) (0.065 * scaleDistance(distance)));
         fluidGroupRenderer.setSpacing(spacing);
         fluidGroupRenderer.setRenderText(Config.renderText);
+        fluidGroupRenderer.setFullBright(true);
     }
 
     private void renderHologramFluids(List<FluidTankInfo> fluidTankInfos) {
         if (fluidTankInfos.isEmpty()) return;
         fluidGroupRenderer.renderFluids(fluidTankInfos);
+    }
+
+    // sublinear for item scale
+    private static double scaleDistance(double distance) {
+        return Math.pow(Math.max(MIN_SCALE_DISTANCE, distance), 0.75);
+    }
+
+    // shrink when close, floors at 0.35
+    private static double closeRangeScale(double distance) {
+        return Math.min(1.0, Math.max(0.35, distance / MIN_SCALE_DISTANCE));
     }
 
     /**


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->
container holos had a disproportionate amount of parallax during camera and player movement, these changes anchor it in place while still facing towards the camera. also fixes items appearing dimmer than they are in the gui

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge

https://github.com/user-attachments/assets/9f81e94d-6405-4ffc-b560-263e298a819c


