### PR TITLE
fix: use renderViewEntity for camera math

### DIFF
--- a/src/main/java/net/dries007/holoInventory/client/Renderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/Renderer.java
@@ -453,7 +453,8 @@ public class Renderer {
     }
 
     private static void setRenderPos(float partialTicks) {
-        Entity thePlayer = Minecraft.getMinecraft().thePlayer;
+        Entity thePlayer = Minecraft.getMinecraft().renderViewEntity != null ? Minecraft.getMinecraft().renderViewEntity
+                : Minecraft.getMinecraft().thePlayer;
         double lastTickPosX = thePlayer.lastTickPosX;
         double posX = thePlayer.posX;
         renderPosX = lastTickPosX + (posX - lastTickPosX) * partialTicks;


### PR DESCRIPTION
## Summary
Freecam compat - use renderViewEntity for camera math


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
