### PR TITLE
Show fluids and essentia in AE2 pattern holograms

### DIFF
--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -192,7 +192,8 @@ public class GroupRenderer {
         final String stackSizeText = (itemStack.getMaxStackSize() == 1 && itemStack.stackSize == 1) ? null
                 : doStackSizeCrap(itemStack.stackSize);
         final int realStackSize = renderStack.stackSize;
-        if (!Config.renderMultiple) {
+        // an unstackable item carrying a large stack size holds a counter, not a pile, so never draw copies of it
+        if (!Config.renderMultiple || renderStack.getMaxStackSize() == 1) {
             renderStack.stackSize = 1;
         }
         fakeEntityItem.setEntityItemStack(renderStack);

--- a/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
+++ b/src/main/java/net/dries007/holoInventory/client/GroupRenderer.java
@@ -8,6 +8,7 @@ import java.util.List;
 import net.dries007.holoInventory.Config;
 import net.dries007.holoInventory.HoloInventory;
 import net.dries007.holoInventory.util.Helper;
+import net.dries007.holoInventory.util.NBTKeys;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.RenderHelper;
@@ -192,8 +193,8 @@ public class GroupRenderer {
         final String stackSizeText = (itemStack.getMaxStackSize() == 1 && itemStack.stackSize == 1) ? null
                 : doStackSizeCrap(itemStack.stackSize);
         final int realStackSize = renderStack.stackSize;
-        // an unstackable item carrying a large stack size holds a counter, not a pile, so never draw copies of it
-        if (!Config.renderMultiple || renderStack.getMaxStackSize() == 1) {
+        if (!Config.renderMultiple
+                || (renderStack.hasTagCompound() && renderStack.getTagCompound().getBoolean(NBTKeys.NBT_KEY_AMOUNT))) {
             renderStack.stackSize = 1;
         }
         fakeEntityItem.setEntityItemStack(renderStack);

--- a/src/main/java/net/dries007/holoInventory/compat/AE2Patterns.java
+++ b/src/main/java/net/dries007/holoInventory/compat/AE2Patterns.java
@@ -1,0 +1,36 @@
+package net.dries007.holoInventory.compat;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import appeng.api.implementations.ICraftingPatternItem;
+import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.api.storage.data.IAEItemStack;
+import appeng.util.Platform;
+
+/**
+ * AE2 is a compile only dependency, so everything that widens an AE2 type has to live in a class that is only ever
+ * loaded when AE2 is present.
+ */
+public class AE2Patterns {
+
+    private AE2Patterns() {}
+
+    @Nullable
+    public static ItemStack getPatternOutput(ItemStack pattern, World w) {
+        if (pattern == null || !(pattern.getItem() instanceof ICraftingPatternItem)) return null;
+        final ICraftingPatternDetails pd = ((ICraftingPatternItem) pattern.getItem()).getPatternForItem(pattern, w);
+        if (pd == null) return null;
+        final IAEItemStack[] outs = pd.getCondensedOutputs();
+        if (outs == null || outs.length == 0 || outs[0] == null) return null;
+        // AE2FC encodes fluids as drop items, which render as a plain droplet.
+        // Convert to a fluid packet so the hologram shows the fluid itself.
+        final IAEItemStack out = Platform.stackConvertPacket(outs[0]);
+        if (out == null) return null;
+        final ItemStack output = out.getItemStack();
+        output.stackSize = (int) Math.min(outs[0].getStackSize(), Integer.MAX_VALUE);
+        return output;
+    }
+}

--- a/src/main/java/net/dries007/holoInventory/compat/AE2Patterns.java
+++ b/src/main/java/net/dries007/holoInventory/compat/AE2Patterns.java
@@ -1,13 +1,18 @@
 package net.dries007.holoInventory.compat;
 
+import static net.dries007.holoInventory.util.NBTKeys.NBT_KEY_AMOUNT;
+
 import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 import appeng.api.implementations.ICraftingPatternItem;
 import appeng.api.networking.crafting.ICraftingPatternDetails;
+import appeng.api.storage.data.IAEFluidStack;
 import appeng.api.storage.data.IAEItemStack;
+import appeng.api.storage.data.IAEStack;
 import appeng.util.Platform;
 
 /**
@@ -23,14 +28,28 @@ public class AE2Patterns {
         if (pattern == null || !(pattern.getItem() instanceof ICraftingPatternItem)) return null;
         final ICraftingPatternDetails pd = ((ICraftingPatternItem) pattern.getItem()).getPatternForItem(pattern, w);
         if (pd == null) return null;
-        final IAEItemStack[] outs = pd.getCondensedOutputs();
+        final IAEStack<?>[] outs = pd.getCondensedAEOutputs();
         if (outs == null || outs.length == 0 || outs[0] == null) return null;
-        // AE2FC encodes fluids as drop items, which render as a plain droplet.
-        // Convert to a fluid packet so the hologram shows the fluid itself.
-        final IAEItemStack out = Platform.stackConvertPacket(outs[0]);
-        if (out == null) return null;
-        final ItemStack output = out.getItemStack();
-        output.stackSize = (int) Math.min(outs[0].getStackSize(), Integer.MAX_VALUE);
+        final IAEStack<?> out = outs[0];
+
+        final ItemStack output;
+        if (out instanceof IAEFluidStack) {
+            // getItemStackForNEI sends fluids through NEI, which hands back a stackable GregTech display item,
+            // and the renderer would then draw one copy per mB. The AE2FC packet is unstackable.
+            final IAEItemStack packet = Platform.stackConvertPacket(out);
+            output = packet == null ? null : packet.getItemStack();
+        } else {
+            output = out.getItemStackForNEI();
+        }
+        if (output == null) return null;
+
+        output.stackSize = (int) Math.min(out.getStackSize(), Integer.MAX_VALUE);
+        // anything but an item stack is a resource amount shown on a display item, not a number of items,
+        // so the renderer must not turn it into a pile of copies
+        if (!(out instanceof IAEItemStack)) {
+            if (!output.hasTagCompound()) output.setTagCompound(new NBTTagCompound());
+            output.getTagCompound().setBoolean(NBT_KEY_AMOUNT, true);
+        }
         return output;
     }
 }

--- a/src/main/java/net/dries007/holoInventory/server/ServerEventHandler.java
+++ b/src/main/java/net/dries007/holoInventory/server/ServerEventHandler.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import net.dries007.holoInventory.Config;
 import net.dries007.holoInventory.HoloInventory;
+import net.dries007.holoInventory.compat.AE2Patterns;
 import net.dries007.holoInventory.network.RemoveInventoryMessage;
 import net.dries007.holoInventory.network.RenameMessage;
 import net.dries007.holoInventory.util.Coord;
@@ -58,11 +59,8 @@ import net.minecraftforge.fluids.IFluidHandler;
 
 import com.github.bsideup.jabel.Desugar;
 
-import appeng.api.implementations.ICraftingPatternItem;
-import appeng.api.networking.crafting.ICraftingPatternDetails;
 import appeng.api.parts.IPartHost;
 import appeng.api.parts.SelectedPart;
-import appeng.api.storage.data.IAEItemStack;
 import appeng.parts.misc.PartInterface;
 import appeng.tile.misc.TileInterface;
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -368,14 +366,7 @@ public class ServerEventHandler {
         int N = patterns.getSizeInventory();
         final ItemStack[] outputs = new ItemStack[N];
         for (int i = 0; i < N; ++i) {
-            final ItemStack stack = patterns.getStackInSlot(i);
-            outputs[i] = null;
-            if (stack != null && stack.getItem() instanceof ICraftingPatternItem) {
-                ICraftingPatternDetails pd = ((ICraftingPatternItem) stack.getItem()).getPatternForItem(stack, w);
-                if (pd == null) continue;
-                IAEItemStack[] outs = pd.getCondensedOutputs();
-                if (outs != null && outs.length > 0) outputs[i] = outs[0].getItemStack();
-            }
+            outputs[i] = AE2Patterns.getPatternOutput(patterns.getStackInSlot(i), w);
         }
         return new FakeInventory(name, outputs);
     }

--- a/src/main/java/net/dries007/holoInventory/util/NBTKeys.java
+++ b/src/main/java/net/dries007/holoInventory/util/NBTKeys.java
@@ -8,6 +8,8 @@ public class NBTKeys {
     public static final String NBT_KEY_CLASS = "class";
     public static final String NBT_KEY_COUNT = "Count";
     public static final String NBT_KEY_TYPE = "type";
+    /** Set on a display item whose stack size is a resource amount, so that it is not rendered as a pile. */
+    public static final String NBT_KEY_AMOUNT = "holoAmount";
     public static final String NBT_KEY_TANK = "tank";
     public static final String NBT_KEY_CAPACITY = "capacity";
     public static final String NBT_KEY_DIM = "dim";


### PR DESCRIPTION
## Summary
AE2FC encodes fluids inside patterns as drop items, so an interface hologram rendered a generic droplet silhouette, while the fluid configured on a Fluid Interface rendered as the fluid itself.

Pattern outputs now come from getCondensedAEOutputs instead of the deprecated getCondensedOutputs, which only carries item stacks. Fluids are turned into AE2FC packets, everything else goes through getItemStackForNEI, so essentia patterns are shown as well rather than leaving an empty slot.

AE2 is a compile only dependency, so this lives in its own class. Widening IAEItemStack to IAEStack at the call site makes the verifier load IAEStack, which crashed the mod on startup without AE2 installed.

A fluid or essentia display item carries a resource amount as its stack size, and the renderer draws one copy per unit, which turned 1000 mB into a pile. Such stacks are now flagged server side and drawn as a single copy.

Needs https://github.com/GTNewHorizons/AE2FluidCraft-Rework/pull/460 to display correctly, the fluid is edge-on to the player without it.

<img width="364" height="67" alt="javaw_r6HZdY9YoV" src="https://github.com/user-attachments/assets/7a9aee49-8fee-4655-836d-4418a7b89e5c" />

|Before|After|
|-|-|
|<img width="1067" height="599" alt="javaw_EgclOPSDVj" src="https://github.com/user-attachments/assets/dabfd2c2-93bb-460e-b7dd-a76b1b34c214" />|<img width="1418" height="622" alt="image" src="https://github.com/user-attachments/assets/7e6c8490-d6ac-4704-a8a2-6714cb3bbe87" />|

## Checklist
- [ ] I have tested this PR in DevEnv
- [X] I have tested this PR in Fullpack
- [X] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [X] This PR requires another PR in order to merge
